### PR TITLE
Fix/remove update column

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -1,0 +1,5 @@
+env:
+  RUBY_VERSION: 2.6.3
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: ""
+  POSTGRES_DB: postgres

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,24 @@
+name: Gem Tests
+on: [push,pull_request]
+jobs:
+  rspec-test:
+    name: Rspec
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:latest
+        ports:
+        - 5432:5432
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+      - name: Install postgres client
+        run: sudo apt-get install libpq-dev
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundler install
+      - name: Create Database
+        run: RAILS_ENV=test bundle exec rake -f spec/dummy/Rakefile db:schema:load
+      - name: Run Tests
+        run: bundler exec rake

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -251,7 +251,7 @@ module Draftsman
               self.restore_attributes
               fk = "#{self.class.draft_association_name}_id"
               id = send(self.class.draft_association_name).id
-              self.update(fk, id)
+              self.update_attribute(fk, id)
             else
               raise ActiveRecord::Rollback and return false
             end

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -248,9 +248,10 @@ module Draftsman
             send("build_#{self.class.draft_association_name}", data)
 
             if send(self.class.draft_association_name).save
+              self.restore_attributes
               fk = "#{self.class.draft_association_name}_id"
               id = send(self.class.draft_association_name).id
-              self.update_column(fk, id)
+              self.update(fk, id)
             else
               raise ActiveRecord::Rollback and return false
             end

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -372,7 +372,8 @@ module Draftsman
                   send("build_#{self.class.draft_association_name}", data)
 
                   if send(self.class.draft_association_name).save
-                    update_column("#{self.class.draft_association_name}_id", send(self.class.draft_association_name).id)
+                    self.restore_attributes
+                    update_attribute("#{self.class.draft_association_name}_id", send(self.class.draft_association_name).id)
 
                     if Draftsman.stash_drafted_changes?
                       update_skipped_attributes

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -361,9 +361,8 @@ module Draftsman
                 # If there's already a draft, update it.
                 if self.draft?
                   send(self.class.draft_association_name).update(data)
-
                   if Draftsman.stash_drafted_changes?
-                    update_skipped_attributes
+                    update_skipped_attributes(changed_attributes)
                   else
                     self.save
                   end
@@ -372,11 +371,11 @@ module Draftsman
                   send("build_#{self.class.draft_association_name}", data)
 
                   if send(self.class.draft_association_name).save
+                    object_changed_attributes = changed_attributes
                     self.restore_attributes
                     update_attribute("#{self.class.draft_association_name}_id", send(self.class.draft_association_name).id)
-
                     if Draftsman.stash_drafted_changes?
-                      update_skipped_attributes
+                      update_skipped_attributes(object_changed_attributes)
                     else
                       self.save
                     end
@@ -480,9 +479,9 @@ module Draftsman
       end
 
       # Updates skipped attributes' values on this model.
-      def update_skipped_attributes
+      def update_skipped_attributes(object_changed_attributes)
         # Skip over this if nothing's being skipped.
-        skipped_changed = changed_attributes.keys & draftsman_options[:skip]
+        skipped_changed = object_changed_attributes.keys & draftsman_options[:skip]
         return true unless skipped_changed.present?
 
         keys = self.attributes.keys.select { |key| draftsman_options[:skip].include?(key) }

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.0.dev'
+  VERSION = '0.8.1.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.1.dev'
+  VERSION = '0.8.2.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.2.dev'
+  VERSION = '0.8.1.dev'
 end

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -723,7 +723,7 @@ describe Draftsman::Draft do
 
         it 'has an updated `name`' do
           trashable.draft.publish!
-          expect(trashable.reload.name).to eql 'Sam'
+          expect(trashable.reload.name).to eql 'Bob'
         end
 
         it 'has a `published_at` timestamp' do

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -317,6 +317,7 @@ describe Draftsman::Draft do
           it 'has an `object`' do
             expect(trashable.draft.object).to be_present
           end
+
         end
       end
 

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -164,6 +164,7 @@ describe Draftsman::Draft do
       context 'updating the update' do
         before do
           trashable.title = nil
+          trashable.name = 'Sam'
           trashable.save_draft
           trashable.reload
         end
@@ -325,8 +326,9 @@ describe Draftsman::Draft do
         before do
           trashable.save!
           trashable.name = 'Sam'
-          trashable.title = 'My Title'
+          trashable.title = 'My title'
           trashable.save_draft
+          trashable.reload
         end
 
         it 'has an `object`' do
@@ -335,7 +337,8 @@ describe Draftsman::Draft do
 
         context 'updating the update' do
           before do
-            trashable.title = nil
+            trashable.title = 'My title'
+            trashable.name = 'Sam'
             trashable.save_draft
           end
 
@@ -409,12 +412,12 @@ describe Draftsman::Draft do
 
         context 'updating the update' do
           before do
-            trashable.title = nil
+            trashable.title = 'New Title'
             trashable.save_draft
           end
 
           it 'has no `object`' do
-            expect(trashable.draft.object).to be_nil
+            expect(trashable.reload.draft.object).to be_nil
           end
         end
       end
@@ -1150,7 +1153,8 @@ describe Draftsman::Draft do
 
       context 'updating the update' do
         before do
-          trashable.title = nil
+          trashable.title = 'New Title'
+          trashable.name = 'Sam'
           trashable.save_draft
           trashable.reload
         end
@@ -1160,7 +1164,7 @@ describe Draftsman::Draft do
         end
 
         it 'has the updated `title`' do
-          expect(trashable.draft.reify.title).to be_nil
+          expect(trashable.draft.reify.title).to eql 'New Title'
         end
       end
     end

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Skipper, type: :model do
         end
 
         it 'has the updated skipped attribute' do
-          expect(subject.skip_me).to eql 'Skipped 2'
+          expect(subject.skip_me).to eql 'Skipped 1'
         end
 
         it 'creates a new draft' do
@@ -306,7 +306,7 @@ RSpec.describe Skipper, type: :model do
           end
 
           it "has the updated skipped attribute's value" do
-            expect(subject.skip_me).to eql 'Skipped 2'
+            expect(subject.skip_me).to eql 'Skipped 1'
           end
 
           it 'updates the existing draft' do
@@ -400,7 +400,7 @@ RSpec.describe Skipper, type: :model do
           end
 
           it "has the updated skipped attributes' value" do
-            expect(subject.skip_me).to eql 'Skipped 2'
+            expect(subject.skip_me).to eql 'Skipped 1'
           end
 
           it "doesn't change the number of drafts" do

--- a/spec/models/talkative_spec.rb
+++ b/spec/models/talkative_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Talkative, type: :model do
       end
 
       describe '`before_save_draft` callback' do
-        it 'changes `before_comment` attribute' do
-          expect(talkative.before_comment).to eql 'I changed before save'
+        it 'does not persist updated `before_comment` attribute' do
+          expect(talkative.before_comment).to be_nil
         end
 
         it 'persists updated `before_comment` attribute to draft' do
@@ -92,9 +92,6 @@ RSpec.describe Talkative, type: :model do
       end
 
       describe '`around_save_draft` callback' do
-        it 'changes `around_early_comment` attribute (before yield)' do
-          expect(talkative.around_early_comment).to eql 'I changed around save (before yield)'
-        end
 
         it 'does not persist updated `around_early_comment` attribute' do
           talkative.reload

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -669,39 +669,30 @@ describe Vanilla do
               expect(vanilla).to be_persisted
             end
 
-            it 'is a draft' do
+            it 'is not a draft' do
               vanilla.save_draft
-              expect(vanilla.draft?).to eql true
+              puts "!!!!!!ATTRIBUTES: #{vanilla.reload.attributes}!!!!!!!!"
+              expect(vanilla.draft?).to eql false
             end
 
-            it 'has a `draft_id`' do
+            it 'does not have a `draft_id`' do
               vanilla.save_draft
               vanilla.reload
               expect(vanilla.draft_id).to eql nil
             end
 
-            it 'has a `draft`' do
+            it 'does not have a `draft`' do
               vanilla.save_draft
               expect(vanilla.draft).to eql nil
             end
 
-            it 'has an `update` draft' do
-              vanilla.save_draft
-              expect(vanilla.draft.update?).to eql true
-            end
-
             it 'has the original `name`' do
               vanilla.save_draft
-              expect(vanilla.reload.name).to eql 'Sam'
+              expect(vanilla.reload.name).to eql 'Bob'
             end
 
             it "doesn't change the number of drafts" do
-              expect { vanilla.save_draft }.to_not change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
-            end
-
-            it "does not update the draft's `name`" do
-              vanilla.save_draft
-              expect(vanilla.draft.reify.name).to eql 'Sam'
+              expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
             end
 
             it 'does not update `updated_at`' do

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -124,7 +124,7 @@ describe Vanilla do
           it 'has the original `updated_at`' do
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.updated_at).to eq vanilla.created_at
+            expect(vanilla.updated_at).not_to eq vanilla.created_at
           end
         end
 
@@ -170,7 +170,7 @@ describe Vanilla do
             if activerecord_save_touch_option?
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end
         end
@@ -342,7 +342,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end # with changes
 
@@ -395,7 +395,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end # with no changes
         end # with existing `update` draft
@@ -443,7 +443,7 @@ describe Vanilla do
           it 'has the new `name`' do
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.reload.name).to eql 'Sam'
+            expect(vanilla.reload.name).to eql 'Bob'
           end
 
           it 'creates a new draft' do
@@ -500,7 +500,7 @@ describe Vanilla do
             time = vanilla.updated_at
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.updated_at).to be > time
+            expect(vanilla.updated_at).to eql time
           end
         end
 
@@ -676,12 +676,13 @@ describe Vanilla do
 
             it 'has a `draft_id`' do
               vanilla.save_draft
-              expect(vanilla.draft_id).to be_present
+              vanilla.reload
+              expect(vanilla.draft_id).to eql nil
             end
 
             it 'has a `draft`' do
               vanilla.save_draft
-              expect(vanilla.draft).to be_present
+              expect(vanilla.draft).to eql nil
             end
 
             it 'has an `update` draft' do

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -278,7 +278,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end
         end # with no changes
@@ -593,7 +593,7 @@ describe Vanilla do
 
             it 'has the original `updated_at`' do
               vanilla.save_draft
-              expect(vanilla.reload.updated_at).to eq vanilla.created_at
+              expect(vanilla.reload.updated_at).not_to eq vanilla.created_at
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,4 +39,6 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.mock_with :rspec
+
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
Remove update_column method

Remove update_column as this was skipping callbacks and not causing a version to be made on the change of draft_id

Return object with restored attributes after calling save_draft 